### PR TITLE
Move logic out of html

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -24,11 +24,7 @@
 
     <!-- Page's content -->
     <ion-side-menu-content>
-          <ion-header-bar class="bar bar-header" ng-class="{'bar-energized': weather.forecast.today.state == 'clear-day' || weather.forecast.today.state == 'partly-cloudy-day',
-            'bar-royal': weather.forecast.today.state == 'clear-night' || weather.forecast.today.state == 'partly-cloudy-night',
-            'bar-calm': weather.forecast.today.state == 'rain',
-            'bar-balanced': weather.forecast.today.state == 'cloudy',
-            'bar-assertive': weather.forecast.today.state == 'snow'}">
+          <ion-header-bar class="bar bar-header" ng-class="getBarColor(weather.forecast.today.state)">
               <button class="button" menu-toggle="left">
                   <i class="icon ion-navicon"></i>
               </button>
@@ -37,23 +33,11 @@
           <ion-content>
 
               <!-- Today's weather -->
-              <div class="today-weather"
-                ng-class="{'clear-day-background': weather.forecast.today.state == 'clear-day' || weather.forecast.today.state == 'partly-cloudy-day',
-                    'clear-night-background': weather.forecast.today.state == 'clear-night' || weather.forecast.today.state == 'partly-cloudy-night',
-                    'rain-background': weather.forecast.today.state == 'rain',
-                    'cloudy-background': weather.forecast.today.state == 'cloudy',
-                    'snow-background': weather.forecast.today.state == 'snow'}">
+              <div class="today-weather" ng-class="getColor(weather.forecast.today.state)">
                   <h2 class="text-center">{{weather.forecast.today.day | date:'EEEE'}}</h2>
                   <div class="row">
                       <div class="col col-50 text-center">
-                          <i class="icon big-icon"
-                            ng-class="{'ion-ios-sunny-outline': weather.forecast.today.state == 'clear-day',
-                                'ion-ios-partlysunny-outline': weather.forecast.today.state == 'partly-cloudy-day',
-                                'ion-ios-moon-outline': weather.forecast.today.state == 'clear-night',
-                                'ion-ios-cloudy-night-outline': weather.forecast.today.state == 'partly-cloudy-night',
-                                'ion-ios-rainy-outline': weather.forecast.today.state == 'rain',
-                                'ion-ios-cloudy-outline': weather.forecast.today.state == 'cloudy',
-                                'ion-ios-snowy': weather.forecast.today.state == 'snow'}">
+                          <i class="icon big-icon" ng-class="getIcon(weather.forecast.today.state)">
                             </i>
                       </div>
                       <div class="col col-50 col-center text-center">
@@ -62,13 +46,13 @@
                   </div>
                   <div class="row">
                       <div class="col text-center">Precipitation: </div>
-                      <div class="col">{{weather.forecast.today.precipitation * 100}}%</div>
+                      <div class="col">{{weather.forecast.today.precipitation}}%</div>
                       <div class="col text-center">Feels like: </div>
                       <div class="col">{{weather.forecast.today.feelsLike}}&#176;</div>
                   </div>
                   <div class="row">
                       <div class="col text-center">Humidity: </div>
-                      <div class="col">{{weather.forecast.today.humidity * 100}}%</div>
+                      <div class="col">{{weather.forecast.today.humidity}}%</div>
                       <div class="col text-center">Wind: </div>
                       <div class="col">{{weather.forecast.today.windSpeed}} {{weather.currentUnits.speed}}</div>
                   </div>
@@ -77,20 +61,12 @@
               <!-- Weather for the week -->
               <ion-list>
                   <div ng-repeat="day in weather.forecast.week" ng-click="clicked = !clicked">
-                      <ion-item class="day"
-                        ng-class="{'clear-day-background': day.state == 'clear-day' || day.state == 'partly-cloudy-day',
-                            'rain-background': day.state == 'rain',
-                            'cloudy-background': day.state == 'cloudy',
-                            'snow-background': day.state == 'snow'}">
+                      <ion-item class="day" ng-class="getColor(day.state)">
                           <div class="row row-no-padding">
                               <div class="col col-50 col-center">{{day.day | date: 'EEEE'}}</div>
                               <div class="col text-right">
                                   <i class="icon"
-                                    ng-class="{'ion-ios-sunny-outline': day.state == 'clear-day',
-                                        'ion-ios-partlysunny-outline': day.state == 'partly-cloudy-day',
-                                        'ion-ios-rainy-outline': day.state == 'rain',
-                                        'ion-ios-cloudy-outline': day.state == 'cloudy',
-                                        'ion-ios-snowy': day.state == 'snow'}">
+                                    ng-class="getIcon(day.state)">
                                     </i>
                               </div>
                               <div class="col text-center col-center">{{day.high}}&#176;</div>
@@ -99,13 +75,13 @@
                             ng-class="{'day-details-clicked': clicked, '': !clicked}">
                               <div class="row">
                                   <div class="col text-center">Precipitation: </div>
-                                  <div class="col">{{day.precipitation * 100}}%</div>
+                                  <div class="col">{{day.precipitation}}%</div>
                                   <div class="col text-center">Low: </div>
                                   <div class="col">{{day.low}}&#176;</div>
                               </div>
                               <div class="row">
                                   <div class="col text-center">Humidity: </div>
-                                  <div class="col">{{day.humidity * 100}}%</div>
+                                  <div class="col">{{day.humidity}}%</div>
                                   <div class="col text-center">Wind: </div>
                                   <div class="col">{{day.windSpeed}} {{weather.currentUnits.speed}}</div>
                               </div>

--- a/www/index.html
+++ b/www/index.html
@@ -15,7 +15,7 @@
 
     <!-- your app's js -->
     <script src="js/app.js"></script>
-    <script src="js/MainCtrl.js"></script>
+    <script src="js/WeatherCtrl.js"></script>
     <script src="js/ApiCallFactory.js"></script>
     <script src="js/ForecastFactory.js"></script>
   </head>

--- a/www/js/ForecastFactory.js
+++ b/www/js/ForecastFactory.js
@@ -10,8 +10,8 @@ app.factory('ForecastFactory', function(ApiCallFactory) {
             state: normalizeState(data.currently.icon, true),
             high: Math.round(data.daily.data[0].temperatureMax),
             low: Math.round(data.daily.data[0].temperatureMin),
-            precipitation: data.daily.data[0].precipProbability,
-            humidity: data.daily.data[0].humidity,
+            precipitation: Math.round(data.daily.data[0].precipProbability * 100),
+            humidity: Math.round(data.daily.data[0].humidity * 100),
             feelsLike: Math.round(data.currently.apparentTemperature),
             windSpeed: Math.round(data.currently.windSpeed)
         };
@@ -24,8 +24,8 @@ app.factory('ForecastFactory', function(ApiCallFactory) {
                 state: normalizeState(data.daily.data[i].icon, false),
                 high: Math.round(data.daily.data[i].temperatureMax),
                 low: Math.round(data.daily.data[i].temperatureMin),
-                precipitation: data.daily.data[i].precipProbability,
-                humidity: data.daily.data[i].humidity,
+                precipitation: Math.round(data.daily.data[i].precipProbability * 100),
+                humidity: Math.round(data.daily.data[i].humidity * 100),
                 windSpeed: Math.round(data.daily.data[i].windSpeed)
             });
         };

--- a/www/js/WeatherCtrl.js
+++ b/www/js/WeatherCtrl.js
@@ -64,6 +64,73 @@ app.controller('WeatherCtrl', function($scope, $ionicSideMenuDelegate,
         });
     };
 
+    //Returns the corresponding background color css class to a day state
+    $scope.getColor = function(state) {
+        var background;
+
+        if(state == 'partly-cloudy-day') {
+            background = 'clear-day-background';
+        }
+        else if(state == 'partly-cloudy-night'){
+            background = 'clear-night-background';
+        }
+        else {
+            background = state + '-background';
+        }
+        return background;
+    };
+
+    //Returns the corresponding icon to a day state
+    $scope.getIcon = function(state) {
+        var icon;
+
+        if(state == 'clear-day') {
+            icon = 'ion-ios-sunny-outline';
+        }
+        else if(state == 'partly-cloudy-day') {
+            icon = 'ion-ios-partlysunny-outline';
+        }
+        else if(state == 'clear-night') {
+            icon = 'ion-ios-moon-outline';
+        }
+        else if(state == 'partly-cloudy-night') {
+            icon = 'ion-ios-cloudy-night-outline';
+        }
+        else if(state == 'rain') {
+            icon = 'ion-ios-rainy-outline';
+        }
+        else if(state == 'cloudy') {
+            icon = 'ion-ios-cloudy-outline';
+        }
+        else if(state == 'snow') {
+            icon = 'ion-ios-snowy';
+        }
+
+        return icon;
+    };
+
+    $scope.getBarColor = function(state) {
+        var color;
+
+        if(state == 'clear-day' || state == 'partly-cloudy-day') {
+            color = 'bar-energized';
+        }
+        else if(state == 'clear-night' || state == 'partly-cloudy-night') {
+            color = 'bar-royal';
+        }
+        else if(state == 'rain') {
+            color = 'bar-calm';
+        }
+        else if(state == 'cloudy') {
+            color = 'bar-balanced';
+        }
+        else if(state == 'snow') {
+            color = 'bar-assertive';
+        }
+
+        return color;
+    };
+
     /* Converts temperature from Celsius to Fahrenheit or
     from Fahrenheit to Celsius */
     function invertTempUnit(temp) {

--- a/www/js/WeatherCtrl.js
+++ b/www/js/WeatherCtrl.js
@@ -1,0 +1,93 @@
+// Main Controller moved in different file suggested by Adam Vigneaux
+app.controller('WeatherCtrl', function($scope, $ionicSideMenuDelegate,
+    ForecastFactory) {
+
+    var weather = this;
+    var celsius = false;
+    var kmh = false;
+    var SPEED_UNIT_CONSTANT = 0.62137;
+
+    weather.forecast = ForecastFactory;
+
+    $scope.temperatureUnitList = [
+        { text: "Fahrenheit", value: "f" },
+        { text: "Celcius", value: "c" }
+    ];
+
+    $scope.speedUnitList = [
+        { text: "Mph", value: "mph" },
+        { text: "Km/h", value: "kmh" }
+    ];
+
+    $scope.data = {
+        temperature: 'f',
+        speed: 'mph'
+    };
+
+    weather.currentUnits = {
+        temperature: 'F',
+        speed: 'mph'
+    };
+
+    $scope.speedUnitChange = function(item) {
+        kmh = !kmh;
+
+        //today
+        weather.forecast.today.windSpeed = invertSpeedUnit(weather.forecast.today.windSpeed);
+
+        //week
+        weather.forecast.week.forEach(function(day) {
+            day.windSpeed = invertSpeedUnit(day.windSpeed);
+        });
+
+        //unit
+        if(kmh) {
+            weather.currentUnits.speed = 'km/h';
+        }
+        else {
+            weather.currentUnits.speed = 'mph';
+        }
+    };
+
+    $scope.temperatureUnitChange = function(item) {
+        celsius = !celsius;
+
+        //today
+        weather.forecast.today.high = invertTempUnit(weather.forecast.today.high);
+        weather.forecast.today.low = invertTempUnit(weather.forecast.today.low);
+        weather.forecast.today.feelsLike = invertTempUnit(weather.forecast.today.feelsLike);
+
+        //week
+        weather.forecast.week.forEach(function(day) {
+            day.high = invertTempUnit(day.high);
+            day.low = invertTempUnit(day.low);
+        });
+    };
+
+    /* Converts temperature from Celsius to Fahrenheit or
+    from Fahrenheit to Celsius */
+    function invertTempUnit(temp) {
+        var newTemp;
+
+        if(celsius) {
+            newTemp = Math.round((temp - 32) * (5/9));
+        }
+        else {
+            newTemp = Math.round((temp * 1.8) + 32);
+        }
+        return newTemp;
+    };
+
+    /* Converts speed from mph to km/h or from km/h to mph */
+    function invertSpeedUnit(speed) {
+        var newSpeed;
+
+        if(kmh) {
+            newTemp = Math.round(speed/SPEED_UNIT_CONSTANT);
+        }
+        else {
+            newTemp = Math.round(speed * SPEED_UNIT_CONSTANT);
+        }
+        return newTemp;
+    };
+});


### PR DESCRIPTION
I moved the logic inside ng-class from the HTML to WeatherCtrl. The HTML now calls a function in the controller and this function returns the name of the css class it needs (different functions for background-color, icon or bar-color). The functions are made of multiple conditional closes which feels ugly, but it is still much cleaner and easier to read than when this logic was in the HTML.